### PR TITLE
changed us to uc

### DIFF
--- a/lib/Test/Arrow.pm
+++ b/lib/Test/Arrow.pm
@@ -304,7 +304,7 @@ Just pass or fail
 
 Similar to C<is> and C<isnt> compare values with C<eq> and C<ne>.
 
-    $arr->expect('FOO')->got(us 'foo')->is;
+    $arr->expect('FOO')->got(uc 'foo')->is;
 
 =head3 is_num
 
@@ -318,7 +318,7 @@ Similar to C<is_num> and C<isnt_num> compare values with C<==> and C<!=>.
 
 The $got will be compare with expected value.
 
-    $arr->expect(us 'foo')->to_be('FOO');
+    $arr->expect(uc 'foo')->to_be('FOO');
 
 =head3 like
 


### PR DESCRIPTION
Hey, I saw this on recent uploads on CPAN. I think this is a very cool project. Reminds me of Mocha and Jest from JS land, which are pretty cool once you get used to it.

I assume that in the examples, you meant to write 'uc', not 'us'.